### PR TITLE
Remove line about GQL being on docs.notifi.network

### DIFF
--- a/docs/alert-subscribe/graphql-api/index.md
+++ b/docs/alert-subscribe/graphql-api/index.md
@@ -7,6 +7,5 @@ but if it does not cover your use case, the GraphQL API is located at
 https://api.notifi.network/gql, and includes both an introspection schema
 and a UI that you can use to submit GraphQL queries and mutations.
 
-The full documentation is located at https://docs.notifi.network/.
 If you need any assistance with the GraphQL API, please reach out
 to integrations@notifi.network!


### PR DESCRIPTION
Since https://docs.notifi.network now points to this site, the line about the GQL API docs being hosted there no longer makes sense.