### PR TITLE
Include a docs.notifi.network CNAME file

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+docs.notifi.network


### PR DESCRIPTION
- This means that the site will automatically link to docs.notifi.network rather than needing to be set every time